### PR TITLE
Initial Crackt Compatibility

### DIFF
--- a/common/src/main/resources/data/jobsplus/arc/miner/break_common_ore.json
+++ b/common/src/main/resources/data/jobsplus/arc/miner/break_common_ore.json
@@ -13,17 +13,30 @@
   ],
   "conditions": [
     {
-      "type": "arc:is_ore"
-    },
-    {
-      "type": "arc:blocks",
-      "inverted": true,
-      "blocks": [
-        "minecraft:diamond_ore",
-        "minecraft:deepslate_diamond_ore",
-        "minecraft:emerald_ore",
-        "minecraft:deepslate_emerald_ore",
-        "minecraft:ancient_debris"
+      "type": "arc:or",
+      "conditions": [
+        {
+          "type": "arc:is_ore",
+          "conditions": [
+            {
+              "type": "arc:blocks",
+              "inverted": true,
+              "blocks": [
+                "minecraft:diamond_ore",
+                "minecraft:deepslate_diamond_ore",
+                "minecraft:emerald_ore",
+                "minecraft:deepslate_emerald_ore",
+                "minecraft:ancient_debris"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "arc:blocks",
+          "blocks": [
+            "crackt:cracking_cluster"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
https://modrinth.com/mod/crackt

Players get experience when mining clusters.

It's not perfect, since it doesn't make distinctions between uncommon and common ores and it only gives the xp per cluster block mined instead of doing it per each block in the vein.

Still better than nothing.