### PR TITLE
Initial Chopt Compatibility

### DIFF
--- a/common/src/main/resources/data/jobsplus/arc/lumberjack/break_wood.json
+++ b/common/src/main/resources/data/jobsplus/arc/lumberjack/break_wood.json
@@ -19,7 +19,8 @@
     {
       "type": "arc:blocks",
       "blocks": [
-        "#minecraft:mineable/axe"
+        "#minecraft:mineable/axe",
+        "chopt:shrinking_stump"
       ]
     }
   ]


### PR DESCRIPTION
https://modrinth.com/mod/chopt

Players get experience when mining shrinking stumps.

It only gives the xp per stump chopped instead of doing it per each block in the tree.